### PR TITLE
new_feature_update_ami

### DIFF
--- a/templates/quickstart-duo-mfa.yaml
+++ b/templates/quickstart-duo-mfa.yaml
@@ -464,7 +464,7 @@ Resources:
     Type: AWS::AutoScaling::LaunchConfiguration
     Properties:
       ImageId: !Ref LatestAmiId
-      InstanceType: t2.micro
+      InstanceType: t3.micro
       IamInstanceProfile: !Ref InstanceProfile
       SecurityGroups:
       - !Ref DuoRadiusProxySecurityGroup
@@ -474,8 +474,10 @@ Resources:
   #-------------------------------------------------
   RadiusProxyAutoScalingGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
+    UpdatePolicy:
+      AutoScalingReplacingUpdate:
+        WillReplace: true
     Properties:
-      AutoScalingGroupName: !Sub RadiusProxyAutoScalingGroup-${DirectoryServiceId}
       VPCZoneIdentifier:
         - !GetAtt GetDirectoryServiceDetails.SubnetId1
         - !GetAtt GetDirectoryServiceDetails.SubnetId2


### PR DESCRIPTION
changed the default instance to be t3.micro for cost saving and more performance over the t2.micro. Also added ability to update the AMI and have it push the new AMI out in production.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
