### PR TITLE
Incorrect detects drift

### DIFF
--- a/templates/quickstart-duo-mfa.yaml
+++ b/templates/quickstart-duo-mfa.yaml
@@ -457,11 +457,11 @@ Resources:
         SourceSecurityGroupId: !GetAtt GetDirectoryServiceDetails.SecurityGroupId
         Description: Allows UDP from Directory Service Domain Controllers
       SecurityGroupEgress:
-      - IpProtocol: 6
+      - IpProtocol: tcp
         FromPort: 80
         ToPort: 80
         CidrIp: 0.0.0.0/0
-      - IpProtocol: 6
+      - IpProtocol: tcp
         FromPort: 443
         ToPort: 443
         CidrIp: 0.0.0.0/0


### PR DESCRIPTION
Changed IpProtocol from 6 to tcp to fix incorrect drift detection.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
