### PR TITLE
Make radius timeout and retry configurable

### DIFF
--- a/functions/source/lambda_function.py
+++ b/functions/source/lambda_function.py
@@ -11,8 +11,6 @@ class RadiusStatus(Enum):
     NotConfigured = 4
 
 # Constants
-RADIUS_TIMEOUT = 10
-RADIUS_RETRIES = 3
 RADIUS_AUTHENTICATION_PROTOCOL = 'PAP'
 
 ds_client = boto3.client('ds')
@@ -59,12 +57,14 @@ def enable_radius(directory_service_id, instance_private_ip_addresses):
 
     radius_port_number = int(os.environ['radius_proxy_port_number'])
     radius_shared_secret = get_radius_shared_secret(os.environ['radius_shared_secret_arn'])
+    radius_timeout = int(os.environ['radius_timeout'])
+    radius_retries = int(os.environ['radius_retries'])
 
     radius_settings = {
         "RadiusServers": instance_private_ip_addresses,
         "RadiusPort": radius_port_number,
-        "RadiusTimeout": RADIUS_TIMEOUT,
-        "RadiusRetries": RADIUS_RETRIES,
+        "RadiusTimeout": radius_timeout,
+        "RadiusRetries": radius_retries,
         "SharedSecret": radius_shared_secret,
         "AuthenticationProtocol": RADIUS_AUTHENTICATION_PROTOCOL,
         "DisplayLabel": "Duo MFA"

--- a/templates/duo-proxy-fargate-main.template.yaml
+++ b/templates/duo-proxy-fargate-main.template.yaml
@@ -34,6 +34,8 @@ Metadata:
         Parameters:
           - RadiusProxyServerCount
           - RadiusPortNumber
+          - RadiusTimeout
+          - RadiusRetries
           - DuoFailMode
           - DuoMaxCapacity
           - NotificationEmail
@@ -100,6 +102,10 @@ Metadata:
         default: RADIUS port number
       RadiusProxyServerCount:
         default: RADIUS proxy server count
+      RadiusTimeout:
+        default: RADIUS timeout
+      RadiusRetries:
+        default: RADIUS number of retries
       VPCCIDR:
         default: VPC CIDR
 Parameters:
@@ -274,6 +280,22 @@ Parameters:
       - 4
     Description: >
       Number of RADIUS proxy Fargate servers to create.
+  RadiusTimeout:
+    Type: Number
+    Description: >
+      Timeout window (in seconds) for each RADIUS request.
+    Default: 10
+    ConstraintDescription: 'Must be in the range [10-50].'
+    MinValue: 10
+    MaxValue: 50
+  RadiusRetries:
+    Type: Number
+    Description: >
+      Total number of retries allowed for each RADIUS request.
+    Default: 3
+    ConstraintDescription: 'Must be in the range [3-10].'
+    MinValue: 3
+    MaxValue: 10
   VPCCIDR:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
     ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
@@ -340,6 +362,8 @@ Resources:
         NotificationEmail: !Ref 'NotificationEmail'
         RadiusProxyServerCount: !Ref 'RadiusProxyServerCount'
         RadiusPortNumber: !Ref 'RadiusPortNumber'
+        RadiusTimeout: !Ref 'RadiusTimeout'
+        RadiusRetries: !Ref 'RadiusRetries'
         DuoFailMode: !Ref 'DuoFailMode'
         QSS3BucketName: !Ref 'QSS3BucketName'
         QSS3BucketRegion: !Ref 'QSS3BucketRegion'

--- a/templates/duo-proxy-fargate.template.yaml
+++ b/templates/duo-proxy-fargate.template.yaml
@@ -24,6 +24,8 @@ Metadata:
           - DirectoryServiceId
           - RadiusProxyServerCount
           - RadiusPortNumber
+          - RadiusTimeout
+          - RadiusRetries
           - DuoFailMode
           - DuoMaxCapacity
           - NotificationEmail
@@ -106,6 +108,10 @@ Metadata:
           default: RADIUS proxy server count
         RadiusPortNumber:
           default: RADIUS port number
+        RadiusTimeout:
+          default: RADIUS timeout
+        RadiusRetries:
+          default: RADIUS number of retries
         DuoFailMode:
           default: Duo fail mode
         QSS3BucketName:
@@ -253,6 +259,24 @@ Parameters:
     ConstraintDescription: 'Must be in the range [1150-65535].'
     MinValue: 1150
     MaxValue: 65535
+
+  RadiusTimeout:
+    Type: Number
+    Description: >
+      Timeout window (in seconds) for each RADIUS request.
+    Default: 10
+    ConstraintDescription: 'Must be in the range [10-50].'
+    MinValue: 10
+    MaxValue: 50
+
+  RadiusRetries:
+    Type: Number
+    Description: >
+      Total number of retries allowed for each RADIUS request.
+    Default: 3
+    ConstraintDescription: 'Must be in the range [3-10].'
+    MinValue: 3
+    MaxValue: 10
 
   DuoFailMode:
     Type: String
@@ -993,6 +1017,8 @@ Resources:
             # feature.
             ds_id: !Ref DirectoryServiceId
             proxy_port: !Ref RadiusPortNumber
+            radius_timeout: !Ref RadiusTimeout
+            radius_retries: !Ref RadiusRetries
             rs_arn: !Ref DuoConfigurationSettingsSecret
             DuoSsm: !Ref DuoServiceIps 
             Topic: !Ref DuoNotification
@@ -1012,9 +1038,7 @@ Resources:
             Completed = 2
             Failed = 3
             NotConfigured = 4
-
-          RADIUS_TIMEOUT = 5
-          RADIUS_RETRIES = 2
+          
           RADIUS_AUTHENTICATION_PROTOCOL = 'PAP'
 
           ds_client = boto3.client('ds')
@@ -1037,12 +1061,14 @@ Resources:
 
               port = int(os.environ['proxy_port'])
               rs = get_rs(os.environ['rs_arn'])
+              radius_timeout = int(os.environ['radius_timeout'])
+              radius_retries = int(os.environ['radius_retries'])
 
               radius_settings = {
                   "RadiusServers": [nlb],
                   "RadiusPort": port,
-                  "RadiusTimeout": RADIUS_TIMEOUT,
-                  "RadiusRetries": RADIUS_RETRIES,
+                  "RadiusTimeout": radius_timeout,
+                  "RadiusRetries": radius_retries,
                   "SharedSecret": rs,
                   "AuthenticationProtocol": RADIUS_AUTHENTICATION_PROTOCOL,
                   "DisplayLabel": "Duo MFA"

--- a/templates/quickstart-duo-mfa-main.template.yaml
+++ b/templates/quickstart-duo-mfa-main.template.yaml
@@ -96,6 +96,10 @@ Metadata:
         default: RADIUS servers
       RadiusPortNumber:
         default: RADIUS port number
+      RadiusTimeout:
+        default: RADIUS timeout
+      RadiusRetries:
+        default: RADIUS number of retries
       DuoFailMode:
         default: Duo fail mode
       VPCCIDR:
@@ -225,6 +229,22 @@ Parameters:
     Type: String
     Description: Port on which to listen for incoming RADIUS access requests
     Default: 1812
+  RadiusTimeout:
+    Type: Number
+    Description: >
+      Timeout window (in seconds) for each RADIUS request.
+    Default: 10
+    ConstraintDescription: 'Must be in the range [10-50].'
+    MinValue: 10
+    MaxValue: 50
+  RadiusRetries:
+    Type: Number
+    Description: >
+      Total number of retries allowed for each RADIUS request.
+    Default: 3
+    ConstraintDescription: 'Must be in the range [3-10].'
+    MinValue: 3
+    MaxValue: 10
   DuoFailMode:
     Type: String
     Description: Once primary authentication succeeds, Safe mode allows authentication attempts,
@@ -391,6 +411,8 @@ Resources:
         DirectoryServiceId: !GetAtt 'ADStack.Outputs.DirectoryID'
         RadiusProxyServerCount: !Ref 'RadiusProxyServerCount'
         RadiusPortNumber: !Ref 'RadiusPortNumber'
+        RadiusTimeout: !Ref 'RadiusTimeout'
+        RadiusRetries: !Ref 'RadiusRetries'
         DuoFailMode: !Ref 'DuoFailMode'
         QSS3BucketName: !Ref 'QSS3BucketName'
         QSS3BucketRegion: !Ref QSS3BucketRegion

--- a/templates/quickstart-duo-mfa.yaml
+++ b/templates/quickstart-duo-mfa.yaml
@@ -31,6 +31,8 @@ Metadata:
           - LatestAmiId
           - RadiusProxyServerCount
           - RadiusPortNumber
+          - RadiusTimeout
+          - RadiusRetries
           - DuoFailMode
 
       - Label:
@@ -55,6 +57,10 @@ Metadata:
           default: RADIUS servers
         RadiusPortNumber:
           default: RADIUS port number
+        RadiusTimeout:
+          default: RADIUS timeout
+        RadiusRetries:
+          default: RADIUS retries
         DuoFailMode:
           default: Duo fail mode
         QSS3BucketName:
@@ -120,6 +126,24 @@ Parameters:
     Description: >
       Port on which to listen for incoming RADIUS access requests
     Default: 1812
+
+  RadiusTimeout:
+    Type: Number
+    Description: >
+      Timeout window (in seconds) for each RADIUS request.
+    Default: 10
+    ConstraintDescription: 'Must be in the range [10-50].'
+    MinValue: 10
+    MaxValue: 50
+
+  RadiusRetries:
+    Type: Number
+    Description: >
+      Total number of retries allowed for each RADIUS request.
+    Default: 3
+    ConstraintDescription: 'Must be in the range [3-10].'
+    MinValue: 3
+    MaxValue: 10
 
   DuoFailMode:
     Type: String
@@ -809,6 +833,8 @@ Resources:
             radius_proxy_port_number: !Ref RadiusPortNumber
             radius_shared_secret_arn: !Ref DuoConfigurationSettingsSecret
             radius_proxy_server_count: !Ref RadiusProxyServerCount
+            radius_timeout: !Ref RadiusTimeout
+            radius_retries: !Ref RadiusRetries
       Tags:
       - Key: duo:DirectoryServiceId
         Value: !Ref DirectoryServiceId


### PR DESCRIPTION
Makes the RADIUS timeout and retry configurable.

Goes with this issue #45 

I refactored the RADIUS_TIMEOUT and RADIUS_RETRIES constants into environment variables set as parameters in the yaml files.
In quickstart-duo-mfa-main.template.yaml I didn't add the new configurable parameters when running DuoAuthProxyFargate.template.yaml since I was unable to find any documentation on it.
