### PR TITLE
Made changes to AD connector type directory

### DIFF
--- a/templates/duo-proxy-fargate.template.yaml
+++ b/templates/duo-proxy-fargate.template.yaml
@@ -328,7 +328,7 @@ Conditions:
   NoKmsAdmin: !Equals
     - !Ref AdminArn
     - ''
-  ManagedAdEgressRule: !!Equals 
+  ManagedAdEgressRule: !Equals 
     - !Ref DirectoryServiceType
     - 'Managed AD'
 

--- a/templates/duo-proxy-fargate.template.yaml
+++ b/templates/duo-proxy-fargate.template.yaml
@@ -22,6 +22,7 @@ Metadata:
             default: RADIUS proxy configuration settings
         Parameters:
           - DirectoryServiceId
+          - DirectoryServiceType
           - RadiusProxyServerCount
           - RadiusPortNumber
           - DuoFailMode
@@ -102,6 +103,8 @@ Metadata:
           default: Duo API hostname
         DirectoryServiceId:
           default: Directory Service ID
+        DirectoryServiceType:
+          default: Directory Service Type
         RadiusProxyServerCount:
           default: RADIUS proxy server count
         RadiusPortNumber:
@@ -119,7 +122,12 @@ Metadata:
 #-----------------------------------------------------------
 
 Parameters:
-
+  DirectoryServiceType:
+    Type: String
+    Description: AD Connector or Managed AD type of directory
+    AllowedValues:
+      - 'AD Connector'
+      - 'Managed AD'
   AdminArn:
     Type: String
     Description: IAM Amazon Resource Name that has administrator rights to the AWS KMS key. If you keep this box blank, KMS key policy will not have an administrator role to administer it.
@@ -320,6 +328,9 @@ Conditions:
   NoKmsAdmin: !Equals
     - !Ref AdminArn
     - ''
+  ManagedAdEgressRule: !!Equals 
+    - !Ref DirectoryServiceType
+    - 'Managed AD'
 
 #-----------------------------------------------------------
 # Resources
@@ -615,10 +626,11 @@ Resources:
 
   #-------------------------------------------------
   # Create the Security Group Egress used by Directory
-  # to talk back to Duo ECS service
+  # to talk back to Duo ECS service for Managed AD
   #-------------------------------------------------
   DirectoryEgressRule:
     Type: AWS::EC2::SecurityGroupEgress
+    Condition: ManagedAdEgressRule
     Properties:
       IpProtocol: udp
       FromPort: !Ref RadiusPortNumber

--- a/templates/duo-proxy-fargate.template.yaml
+++ b/templates/duo-proxy-fargate.template.yaml
@@ -125,6 +125,7 @@ Parameters:
   DirectoryServiceType:
     Type: String
     Description: AD Connector or Managed AD type of directory
+    Default: 'Managed AD'
     AllowedValues:
       - 'AD Connector'
       - 'Managed AD'


### PR DESCRIPTION
*Issue #, if available:*
AD connector creates a security group as a default initialization from AWS EC2 api which makes the egress default. Adding another egress removed the default rule making the Directory in "Inoperable" state
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group.html#aws-properties-ec2-security-group--examples--Remove_the_default_rule

*Description of changes:*
Added a parameter to specify directory type. If type is AD Connector then no egress is added.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
